### PR TITLE
Picasso Integration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,7 @@ dependencies {
 	implementation 'androidx.lifecycle:lifecycle-common-java8:2.3.1'
 	implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 	implementation 'com.squareup.moshi:moshi-kotlin:1.12.0'
+	implementation 'com.squareup.picasso:picasso:2.71828'
 
 	kapt 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 	xmlns:tools="http://schemas.android.com/tools"
 	package="com.droidboi.recyclerView">
 
+	<uses-permission android:name="android.permission.INTERNET" />
+
 	<application
 		android:allowBackup="false"
 		android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Added [Picasso](https://square.github.io/picasso) as a dependency in the `:app` Module.
Also added Permission `android.permission.INTERNET` in the `AndroidManifest.xml` of `:app` Module so that the Picasso works.